### PR TITLE
fix non-suitable created increment

### DIFF
--- a/denormalized/tracker.py
+++ b/denormalized/tracker.py
@@ -30,10 +30,14 @@ class DenormalizedTracker:
             foreign_object = None
         is_suitable = self.callback(instance)
         delta = self._get_delta(instance)
-        if created and is_suitable:
-            return self._update_value(foreign_object, delta, sign=1),
-        elif deleted and is_suitable:
-            return self._update_value(foreign_object, delta, sign=-1),
+        if created:
+            if is_suitable:
+                return self._update_value(foreign_object, delta, sign=1),
+            return []
+        elif deleted:
+            if is_suitable:
+                return self._update_value(foreign_object, delta, sign=-1),
+            return []
         old_instance = getattr(instance, PREVIOUS_VERSION_FIELD)
         old_delta = self._get_delta(old_instance)
         old_suitable = self.callback(old_instance)

--- a/denormalized/tracker.py
+++ b/denormalized/tracker.py
@@ -41,10 +41,7 @@ class DenormalizedTracker:
         old_instance = getattr(instance, PREVIOUS_VERSION_FIELD)
         old_delta = self._get_delta(old_instance)
         old_suitable = self.callback(old_instance)
-        try:
-            old_foreign_object = getattr(old_instance, self.foreign_key)
-        except models.ObjectDoesNotExist:
-            old_foreign_object = None
+        old_foreign_object = getattr(old_instance, self.foreign_key)
 
         sign = is_suitable - old_suitable
         if foreign_object == old_foreign_object and sign != 0:

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -33,9 +33,27 @@ class CountTestCase(TestCase):
 
         self.assertMembersCount()
 
+    def test_skip_increment_on_new(self):
+        """ Creating new non-suitable member leaves counter same."""
+        member = models.Member()
+        member.group = self.group
+        member.active = False
+
+        member.save()
+
+        self.assertMembersCount()
+
     def test_decrement_on_delete(self):
         """ Deleting member decrements counter."""
         self.member.delete()
+
+        self.assertMembersCount()
+
+    def test_skip_decrement_on_delete(self):
+        """ Deleting member decrements counter."""
+        member = models.Member.objects.create(group=self.group, active=False)
+
+        member.delete()
 
         self.assertMembersCount()
 
@@ -54,6 +72,15 @@ class CountTestCase(TestCase):
         self.member.group = group
 
         self.member.save()
+
+        self.assertMembersCount()
+
+    def test_increment_on_set_group(self):
+        """ If object without group is moved to group, increment."""
+        member = models.Member.objects.create(group=None, active=True)
+        member.group = self.group
+
+        member.save()
 
         self.assertMembersCount()
 


### PR DESCRIPTION
When object is created via admin (like `model()`), it has null `old_foreign_object`. So on save old FK not decremented and new one - incremented even if object is not suitable.