### PR TITLE
change save wrapping method

### DIFF
--- a/testproject/testapp/models.py
+++ b/testproject/testapp/models.py
@@ -36,3 +36,12 @@ class Member(models.Model):
 
     class Meta:
         app_label = 'testapp'
+
+    def save(self, force_insert=False, force_update=False, using=None,
+             update_fields=None):
+        """
+        Override base save to test whether overridden save is also wrapped
+        in DenormalizedForeignKey._wrap_save.
+        """
+        super().save(force_insert, force_update, using, update_fields)
+


### PR DESCRIPTION
Old version didn't wrap concrete model `save` method with initial state invalidation. 
New version does this on `class_prepared` signal.