### PR TITLE
fix decrement on change group

### DIFF
--- a/denormalized/tracker.py
+++ b/denormalized/tracker.py
@@ -47,9 +47,12 @@ class DenormalizedTracker:
         if foreign_object == old_foreign_object and sign != 0:
             changed.append(self._update_value(foreign_object, delta, sign=sign))
         elif foreign_object != old_foreign_object:
-            changed.append(self._update_value(
-                old_foreign_object, old_delta, sign=-1))
-            changed.append(self._update_value(foreign_object, delta, sign=1))
+            if old_suitable:
+                changed.append(self._update_value(
+                    old_foreign_object, old_delta, sign=-1))
+            if is_suitable:
+                changed.append(self._update_value(
+                    foreign_object, delta, sign=1))
         else:
             # foreign_object == old_foreign_object and sign == 0
             changed.append(self._update_value(

--- a/testproject/testapp/models.py
+++ b/testproject/testapp/models.py
@@ -44,4 +44,3 @@ class Member(models.Model):
         in DenormalizedForeignKey._wrap_save.
         """
         super().save(force_insert, force_update, using, update_fields)
-

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -84,6 +84,34 @@ class CountTestCase(TestCase):
 
         self.assertMembersCount()
 
+    def test_increment_and_change_group(self):
+        """
+        If object changes group and becomes active, only new group increments.
+        """
+        group = models.Group.objects.create()
+        self.member.active = False
+        self.member.save()
+
+        self.member.active = True
+        self.member.group = group
+        self.member.save()
+
+        self.assertMembersCount()
+        self.assertMembersCount(group)
+
+    def test_decrement_and_change_group(self):
+        """
+        If object changes group and becomes inactive, only old group increments.
+        """
+        group = models.Group.objects.create()
+
+        self.member.active = False
+        self.member.group = group
+        self.member.save()
+
+        self.assertMembersCount()
+        self.assertMembersCount(group)
+
     def test_denormalize(self):
         """ Count can be refreshed from db."""
         self.group.members_count = None


### PR DESCRIPTION
When object becomes suitable and changes FK simultaneously, counter for old FK decrements (incorrectly), making count less than zero.